### PR TITLE
Fix contract.mdx for cross chain mailbox

### DIFF
--- a/src/content/docs/automatic-relayers/contract.mdx
+++ b/src/content/docs/automatic-relayers/contract.mdx
@@ -60,6 +60,8 @@ contract HelloWormhole is IWormholeReceiver {
 **Step 4**: Next, let's add the constructor. This will run once when the contract is deployed. It sets the address of the Wormhole relayer:
 
 ```solidity
+IWormholeRelayer public immutable wormholeRelayer;
+
 constructor(address _wormholeRelayer) {
     wormholeRelayer = IWormholeRelayer(_wormholeRelayer);
 }

--- a/src/content/docs/automatic-relayers/contract.mdx
+++ b/src/content/docs/automatic-relayers/contract.mdx
@@ -53,6 +53,14 @@ import "wormhole-solidity-sdk/interfaces/IWormholeReceiver.sol";
 
 ```solidity
 contract HelloWormhole is IWormholeReceiver {
+    event GreetingReceived(string greeting, uint16 senderChain, address sender);
+
+    uint256 constant GAS_LIMIT = 50_000;
+
+    IWormholeRelayer public immutable wormholeRelayer;
+
+    string public latestGreeting;
+
     // More to come
 }
 ```
@@ -60,8 +68,6 @@ contract HelloWormhole is IWormholeReceiver {
 **Step 4**: Next, let's add the constructor. This will run once when the contract is deployed. It sets the address of the Wormhole relayer:
 
 ```solidity
-IWormholeRelayer public immutable wormholeRelayer;
-
 constructor(address _wormholeRelayer) {
     wormholeRelayer = IWormholeRelayer(_wormholeRelayer);
 }


### PR DESCRIPTION
Include `wormholeRelayer` for it to be initialised in the constructor
`GAS_LIMIT` for quote and send functions
`latestGreeting` and the `GreetingReceived` event for `receiveWormholeMessages`

This is to reduce confusion, although the final code block contains all of it there is no mention in the starting